### PR TITLE
[feat] 프로필(사진, 닉네임) 변경 구현, 탭 기능 구현

### DIFF
--- a/src/app/myprofile/page.tsx
+++ b/src/app/myprofile/page.tsx
@@ -1,18 +1,14 @@
-import Profile from "@/components/myprofile/profile";
-import MyReviewCard from "@/components/myprofile/myReviewCard";
-import MyWineCard from "@/components/myprofile/myWineCard";
+import Profile from "@/components/myprofile/Profile";
+import ProfileTab from "@/components/myprofile/ProfileTab";
 
 export default function MyProfilePage() {
   return (
-    <div>
-      <div className="m-5">
-        <Profile />
-      </div>
-      <div className="m-5">
-        <MyReviewCard />
-      </div>
-      <div className="m-5">
-        <MyWineCard />
+    <div className="mt-[3.7rem] justify-center flex">
+      <div className="flex flex-col tablet:flex-row ">
+        <div className="mr-[6rem]">
+          <Profile />
+        </div>
+        <ProfileTab />
       </div>
     </div>
   );

--- a/src/components/common/dropDownMenu.tsx
+++ b/src/components/common/dropDownMenu.tsx
@@ -28,6 +28,11 @@ export default function DropDownMenu({ onEdit, onDelete }: DropDownMenuProps) {
     setIsOpen(!isOpen);
   }
 
+  function handleMenuClick(callback?: () => void) {
+    if (callback) callback();
+    setIsOpen(false);
+  }
+
   return (
     <div ref={menuRef} className="relative inline-block">
       <button onClick={toggleDropDown}>
@@ -37,14 +42,14 @@ export default function DropDownMenu({ onEdit, onDelete }: DropDownMenuProps) {
       {isOpen && (
         <div className="absolute items-center right-0 mt-[0.8rem] w-[12.6rem] h-[10.4rem] border-solid border-[0.1rem] border-gray-300 rounded-[1.6rem] flex flex-col">
           <button
-            onClick={onEdit}
+            onClick={() => handleMenuClick(onEdit)}
             className="w-[12.6rem] h-[5.2rem] text-[1.6rem] font-medium leading-[2.6rem] items-center text-gray-800 
             hover:bg-[#f1edfc]  hover:text-primary hover:rounded-[1.2rem] hover:w-[11.8rem] hover:h-[4.6rem] hover:m-[0.3rem_0.4rem]"
           >
             수정하기
           </button>
           <button
-            onClick={onDelete}
+            onClick={() => handleMenuClick(onDelete)}
             className="w-[12.6rem] h-[5.2rem] text-[1.6rem] font-medium leading-[2.6rem] items-center text-gray-800         
             hover:bg-[#f1edfc] hover:text-primary hover:rounded-[1.2rem] hover:w-[11.8rem] hover:h-[4.6rem] hover:m-[0.3rem_0.4rem]"
           >

--- a/src/components/common/dropDownMenu.tsx
+++ b/src/components/common/dropDownMenu.tsx
@@ -36,22 +36,20 @@ export default function DropDownMenu({ onEdit, onDelete }: DropDownMenuProps) {
   return (
     <div ref={menuRef} className="relative inline-block">
       <button onClick={toggleDropDown}>
-        <Image src={MenuIcon} alt="메뉴 버튼" width={26} height={26} />
+        <Image src={MenuIcon} alt="메뉴 버튼" width={26} />
       </button>
 
       {isOpen && (
         <div className="absolute items-center right-0 mt-[0.8rem] w-[12.6rem] h-[10.4rem] border-solid border-[0.1rem] border-gray-300 rounded-[1.6rem] flex flex-col">
           <button
             onClick={() => handleMenuClick(onEdit)}
-            className="w-[12.6rem] h-[5.2rem] text-[1.6rem] font-medium leading-[2.6rem] items-center text-gray-800 
-            hover:bg-[#f1edfc]  hover:text-primary hover:rounded-[1.2rem] hover:w-[11.8rem] hover:h-[4.6rem] hover:m-[0.3rem_0.4rem]"
+            className="w-[12.6rem] h-[5.2rem] text-[1.6rem] font-medium leading-[2.6rem] items-center dropdown-menu-button"
           >
             수정하기
           </button>
           <button
             onClick={() => handleMenuClick(onDelete)}
-            className="w-[12.6rem] h-[5.2rem] text-[1.6rem] font-medium leading-[2.6rem] items-center text-gray-800         
-            hover:bg-[#f1edfc] hover:text-primary hover:rounded-[1.2rem] hover:w-[11.8rem] hover:h-[4.6rem] hover:m-[0.3rem_0.4rem]"
+            className="w-[12.6rem] h-[5.2rem] text-[1.6rem] font-medium leading-[2.6rem] items-center dropdown-menu-button"
           >
             삭제하기
           </button>

--- a/src/components/myprofile/ProfileTab.tsx
+++ b/src/components/myprofile/ProfileTab.tsx
@@ -1,0 +1,124 @@
+"use client";
+
+import { useState } from "react";
+import MyReviewCard from "./MyReviewCard";
+import MyWineCard from "./MyWineCard";
+import "@/../public/images/placeholder1.png";
+
+const reviews = [
+  {
+    id: 1,
+    rating: 5.0,
+    createdAt: "2024-12-19T03:46:36.139Z",
+    name: "This Wine is Amazing",
+    content: "Highly recommend this wine for dinner parties.",
+  },
+  {
+    id: 2,
+    rating: 4.5,
+    createdAt: "2024-12-17T12:34:00.000Z",
+    name: "Decent Quality Wine",
+    content: "Good flavor, but slightly overpriced in my opinion.",
+  },
+  {
+    id: 3,
+    rating: 4.8,
+    createdAt: "2024-12-16T08:45:12.000Z",
+    name: "Smooth and Elegant",
+    content: "Perfect for a relaxing evening.",
+  },
+  {
+    id: 4,
+    rating: 5.0,
+    createdAt: "2024-12-18T14:46:36.139Z",
+    name: "This Wine is Amazing",
+    content: "Highly recommend this wine for dinner parties.",
+  },
+  {
+    id: 5,
+    rating: 4.5,
+    createdAt: "2024-12-17T12:34:00.000Z",
+    name: "Decent Quality Wine",
+    content: "Good flavor, but slightly overpriced in my opinion.",
+  },
+  {
+    id: 6,
+    rating: 4.8,
+    createdAt: "2024-12-16T08:45:12.000Z",
+    name: "Smooth and Elegant",
+    content: "Perfect for a relaxing evening.",
+  },
+];
+
+const wines = [
+  {
+    id: 1,
+    name: "Sentinel Cabernet Sauvignon 2016",
+    region: "Western Cape, South Africa",
+    image:
+      "https://cdn.discordapp.com/attachments/1275867779723034707/1319138863234420866/wine_image.png?ex=6764df4d&is=67638dcd&hm=3b9b74ebfa5bb12cb818c821c31800c950a1cfdad7fb1bb259bf0b5bae33b4aa&",
+    price: "64,990",
+  },
+  {
+    id: 2,
+    name: "Chateau Margaux 2018",
+    region: "Bordeaux, France",
+    image:
+      "https://cdn.discordapp.com/attachments/1275867779723034707/1319138863234420866/wine_image.png?ex=6764df4d&is=67638dcd&hm=3b9b74ebfa5bb12cb818c821c31800c950a1cfdad7fb1bb259bf0b5bae33b4aa&",
+    price: "320,000",
+  },
+  {
+    id: 3,
+    name: "Silver Oak Cabernet Sauvignon 2019",
+    region: "Napa Valley, USA",
+    image:
+      "https://i.pinimg.com/736x/47/32/2d/47322dba61a25d552f1bd0f9e57cddff.jpg",
+    price: "95,000",
+  },
+];
+
+export default function ProfileTab() {
+  const [activeTab, setActiveTab] = useState("reviews");
+
+  const itemCount = activeTab === "reviews" ? reviews.length : wines.length;
+
+  return (
+    <div className="w-[80rem] h-[3.2rem]">
+      <div className="flex justify-between items-center ">
+        <div>
+          <button
+            className={`w-[9.6rem] h-[3.2rem] text-[2rem] font-semibold leading-[3.2rem] ${activeTab === "reviews" ? "text-gray-800" : "text-gray-500"}`}
+            onClick={() => setActiveTab("reviews")}
+          >
+            내가 쓴 후기
+          </button>
+          <button
+            className={`ml-[3.2rem] w-[13.1rem] h-[3.2rem] text-[2rem] font-semibold leading-[3.2rem] ${activeTab === "wines" ? "text-gray-800" : "text-gray-500"}`}
+            onClick={() => setActiveTab("wines")}
+          >
+            내가 등록한 와인
+          </button>
+        </div>
+        <p className="font-regular text-[1.4rem] leading-[2.4rem] text-right text-primary">
+          {`총 ${itemCount}개`}
+        </p>
+      </div>
+
+      <div>
+        {activeTab === "reviews" ? (
+          <div className="mt-[2.2rem] space-y-[2rem]">
+            {reviews.map((review) => (
+              <MyReviewCard key={review.id} review={review} />
+            ))}
+          </div>
+        ) : (
+          <div className="mt-[2.2rem] space-y-[2rem]">
+            {wines.map((wine) => (
+              <MyWineCard key={wine.id} wine={wine} />
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/myprofile/myReviewCard.tsx
+++ b/src/components/myprofile/myReviewCard.tsx
@@ -1,27 +1,60 @@
 import Image from "next/image";
-import DropDownMenu from "../common/dropDownMenu";
+import DropDownMenu from "../common/DropDownMenu";
 import StarFill from "../../../public/icons/star_fill.svg";
 // import StarEmpty from "../../../public/icons/star.svg";
 
-export default function MyReviewCard() {
+function timeAgo(createdAt: string): string {
+  const now = new Date();
+  const createdDate = new Date(createdAt);
+  const diffInSeconds = Math.floor(
+    (now.getTime() - createdDate.getTime()) / 1000,
+  );
+
+  if (diffInSeconds < 60) {
+    return `${diffInSeconds}초 전`;
+  } else if (diffInSeconds < 3600) {
+    const minutes = Math.floor(diffInSeconds / 60);
+    return `${minutes}분 전`;
+  } else if (diffInSeconds < 86400) {
+    const hours = Math.floor(diffInSeconds / 3600);
+    return `${hours}시간 전`;
+  } else {
+    const days = Math.floor(diffInSeconds / 86400);
+    return `${days}일 전`;
+  }
+}
+
+interface Review {
+  id: number;
+  rating: number;
+  createdAt: string;
+  name: string;
+  content: string;
+}
+
+export default function MyReviewCard({ review }: { review: Review }) {
   return (
-    <div className="w-[80rem] h-[20.2rem] border-solid border-[0.1rem] bg-white rounded-[1.6rem] border-gray-300 p-[2.4rem_4rem]">
+    <div className="w-[80rem] min-h-[20.2rem] border-solid border-[0.1rem] bg-white rounded-[1.6rem] border-gray-300 p-[2.4rem_4rem]">
       <div className="flex justify-between items-center">
         <div className="flex items-center">
           <div className="mr-[1.5rem] w-[8rem] h-[4.2rem] rounded-[1.2rem] p-[0.8rem_1.5rem] bg-[#f1edfc] flex items-center">
             <Image src={StarFill} alt="별점" width={20} height={20} />
-            <p className="text-primary font-bold text-[1.8rem]">5.0</p>
+            <p className="text-primary font-bold text-[1.8rem]">
+              {review.rating.toFixed(1)}
+            </p>
           </div>
-          <p className="text-gray-300 text-[1.6rem] font-regular">7시간 전</p>
+          <p className="text-gray-300 text-[1.6rem] font-regular">
+            {timeAgo(review.createdAt)}
+          </p>
         </div>
         <DropDownMenu />
       </div>
       <div className="mt-[2rem]">
         <div className="leading-[2.6rem] text-[1.6rem] font-medium text-gray-500">
-          this Wine good
+          {review.name}
         </div>
         <div className="text-[1.6rem] font-regular text-gray-800 mt-[1rem] leading-[2.6rem]">
-          wow daebak masisseo
+          {review.content}
         </div>
       </div>
     </div>

--- a/src/components/myprofile/myWineCard.tsx
+++ b/src/components/myprofile/myWineCard.tsx
@@ -1,34 +1,46 @@
 import Image from "next/image";
-import PalceholderWine from "@/../public/images/placeholder1.png";
-import DropDownMenu from "../common/dropDownMenu";
+import DropDownMenu from "../common/DropDownMenu";
 
-export default function MyWineCard() {
+interface Wine {
+  id: number;
+  name: string;
+  region: string;
+  image: string;
+  price: string;
+}
+
+export default function MyWineCard({ wine }: { wine: Wine }) {
   return (
-    <div className="w-[80rem] h-[27rem] flex">
+    <div className="w-[80rem] min-h-[27rem] flex">
       <div className="mt-[4rem]">
-        <div className="relative w-[80rem] h-[22.8rem] border-solid border-[0.1rem] bg-white rounded-[1.6rem] border-gray-300 p-[2.4rem_4rem] flex">
-          <Image
-            src={PalceholderWine}
-            alt="와인사진"
-            width={76}
-            height={270}
-            className="absolute top-[-4.2rem]"
-          />
+        <div className="relative w-[80rem] h-[22.8rem] border-solid border-[0.1rem] bg-white rounded-[1.6rem] border-gray-300 pl-[4rem] flex items-end">
+          <div className="relative w-[7.6rem] h-[27rem] overflow-hidden">
+            <Image
+              src={wine.image}
+              alt="와인사진"
+              layout="fill"
+              objectFit="cover"
+              objectPosition="bottom"
+              className="absolute"
+            />
+          </div>
           <div className="w-[72rem] flex justify-between ">
-            <div className="ml-[11.6rem]">
+            <div className="m-[3rem_0_3rem_4rem]">
               <div className="mb-[2rem]">
                 <p className="break-words max-w-[30rem] text-[3rem] font-semibold leading-[3.58rem] text-gray-800 mb-[2rem]">
-                  Sentinel Carbernet Sauvignon 2016
+                  {wine.name}
                 </p>
                 <p className="text-[1.6rem] font-regular leading-[2.6rem] text-gray-500">
-                  Western Cape, South Africa
+                  {wine.region}
                 </p>
               </div>
-              <p className="bg-[#F1EDFC] w-[11.4rem] h-[3.7rem] p-[0.55rem_1.5rem] rounded-[1.2rem] gap-[1rem] text-[1.8rem] text-primary font-bold leading-[2.6rem]">
-                ₩ 64,990
+              <p className="bg-[#F1EDFC] min-w-[11.4rem] h-[3.7rem] p-[0.55rem_1.5rem] rounded-[1.2rem] gap-[1rem] text-[1.8rem] text-primary font-bold leading-[2.6rem] inline-block">
+                ₩ {wine.price}
               </p>
             </div>
-            <DropDownMenu />
+            <div className="m-[3rem_4rem]">
+              <DropDownMenu />
+            </div>
           </div>
         </div>
       </div>

--- a/src/components/myprofile/profile.tsx
+++ b/src/components/myprofile/profile.tsx
@@ -1,24 +1,78 @@
+"use client";
+
 import Image from "next/image";
 import Button from "../common/Button";
+import DefaultProfile from "@/../public/images/profile_white.svg";
+import CameraIcon from "@/../public/icons/photo.svg";
+import { useState } from "react";
+
+const initialUser = {
+  email: "minjin12345@naver.com",
+  nickname: "푸른별빛의마지막",
+  image:
+    "https://i.pinimg.com/736x/9e/38/af/9e38af2e5d9fd2615d08eeda59487a76.jpg",
+};
 
 export default function Profile() {
+  const [user, setUser] = useState(initialUser);
+  const [newNickname, setNewNickname] = useState("");
+
+  // 닉네임 변경
+  function handleNicknameChange() {
+    if (newNickname.trim()) {
+      setUser((prev) => ({ ...prev, nickname: newNickname }));
+      setNewNickname("");
+    }
+  }
+
+  // 프로필 이미지 변경
+  function handleImageChange(event: React.ChangeEvent<HTMLInputElement>) {
+    const file = event.target.files?.[0];
+    if (file) {
+      const imageUrl = URL.createObjectURL(file);
+      setUser((prev) => ({ ...prev, image: imageUrl }));
+    }
+  }
+
   return (
-    <div className="w-[28rem] h-[53rem] top-[14.7rem] left-[39rem] p-[3.9rem_2rem] border-[0.1rem] border-solid bg-white border-[#cfdbea] rounded-[1.6rem]">
+    <div className="w-[28rem] min-h-[53rem] top-[14.7rem] left-[39rem] p-[3.9rem_2rem] border-[0.1rem] border-solid bg-white border-[#cfdbea] rounded-[1.6rem]">
       <div className="flex justify-center flex-col items-center">
-        <div className="w-[16.4rem] h-[16.4rem] flex items-center justify-center rounded-full">
+        <div
+          onClick={() => document.getElementById("profileImage")?.click()}
+          className="relative group flex items-center justify-center rounded-full cursor-pointer"
+        >
           <Image
-            src="/images/profile_white.svg"
+            src={user.image || DefaultProfile}
             alt="프로필 사진"
             width={164}
             height={164}
+            className="w-[16.4rem] h-[16.4rem] rounded-full"
+          />
+          <div className="absolute rounded-full inset-0 bg-primary opacity-0 group-hover:opacity-80 transition-opacity"></div>
+          <div className="absolute opacity-0 group-hover:opacity-100">
+            <Image
+              src={CameraIcon}
+              alt="카메라 아이콘"
+              width={40}
+              height={40}
+              className="text-white"
+            />
+          </div>
+          <input
+            id="profileImage"
+            type="file"
+            accept="image/*"
+            className="hidden"
+            onChange={handleImageChange}
           />
         </div>
+
         <div className="flex flex-col items-center justify-center mt-[3.2rem]">
-          <p className="text-[2.4rem] font-bold text-[#2d3034] leading-[3.2rem]">
-            민진
+          <p className="text-[2.4rem] font-bold text-[#2d3034] leading-[3.2rem] text-center">
+            {user.nickname}
           </p>
           <p className="text-[1.6rem] text-[#9FACBD] mt-[1.6rem] font-regular leading-[2.6rem]">
-            minjin@naver.com
+            {user.email}
           </p>
         </div>
       </div>
@@ -27,8 +81,14 @@ export default function Profile() {
           <p className="text-[1.6rem] font-medium leading-[2.6rem]">닉네임</p>
           <input
             type="text"
-            placeholder="민진"
-            className="w-[24rem] h-[4.8rem] p-[1.4rem_2rem] mt-[1rem] border-[0.1rem] bg-white border-[#cfdbea] rounded-[1.6rem] text-[1.6rem] font-regular"
+            placeholder={user.nickname}
+            className="w-[24rem] h-[4.8rem] p-[1.4rem_2rem] mt-[1rem] border-[0.1rem] bg-white border-[#cfdbea] rounded-[1.6rem] text-[1.6rem] font-regular focus:outline-none focus:border-primary"
+            value={newNickname}
+            onChange={(event) => {
+              if (event.target.value.length <= 20) {
+                setNewNickname(event.target.value);
+              }
+            }}
           ></input>
         </div>
 
@@ -37,6 +97,7 @@ export default function Profile() {
           size="small"
           color="primary"
           addClassName="w-[9.6rem] h-[4.2rem] m-[0.8rem_0_0_14.4rem] rounded-[1.2rem] bg-[#6A42DB]"
+          onClick={handleNicknameChange}
         >
           <p className="p-[0.8rem_2rem] text-white text-[16px] font-bold leading-[2.6rem]">
             변경하기

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -535,6 +535,9 @@ template {
   .card-container {
     @apply bg-white rounded-[1.6rem];
   }
+  .dropdown-menu-button {
+    @apply text-gray-800 hover:bg-[#f1edfc] hover:text-primary hover:rounded-[1.2rem] hover:w-[11.8rem] hover:h-[4.6rem] hover:m-[0.3rem_0.4rem];
+  }
 }
 
 @layer utilities {


### PR DESCRIPTION
## 🪐 작업 내용

### 📝 간단하게 설명해주세요
> 프로필 사진과 닉네임 변경 기능 구현
> 닉네임 20자까지만 적을 수 있게 함
> 드롭다운 수정하기 삭제하기 눌렀을 때 메뉴 닫히는 거 구현 (공통으로 빼는 작업은 할 예정)
> 탭 기능 구현(내가 쓴 후기, 내가 등록한 와인)
> 임의 데이터 넣어서 작업 진행함
> 중간중간에 css도 수정했음

### ✨ To-do
- [ ] 프로필 사진을 수정할 수 있게 해주세요.
- [ ] 닉네임을 입력하고 '변경하기' 버튼을 클릭하면 닉네임이 변경되게 해주세요.
- [ ] 내가 작성한 후기 탭에서는 작성한 후기가 나열되게 해주세요.
- [ ] 후기 리스트에서 햄버거 버튼을 클릭하면 수정, 삭제 옵션이 나타나게 해주세요.
- [ ] 내가 등록한 와인 탭에서는 등록한 와인이 나열되게 해주세요.
- [ ] 와인 리스트에서 햄버거 버튼을 클릭하면 수정, 삭제 옵션이 나타나게 해주세요.

### 📸 참고 사진

https://github.com/user-attachments/assets/3a1b7b36-d17e-4556-a632-3778aa615912


