### PR TITLE
Feat: 리뷰 수정모달 API

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "hasInstallScript": true,
       "dependencies": {
+        "@tanstack/react-query": "^5.62.10",
         "autoprefixer": "^10.4.20",
         "axios": "^1.7.9",
         "classnames": "^2.5.1",
@@ -929,6 +930,32 @@
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.62.9",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.62.9.tgz",
+      "integrity": "sha512-lwePd8hNYhyQ4nM/iRQ+Wz2cDtspGeZZHFZmCzHJ7mfKXt+9S301fULiY2IR2byJYY6Z03T427E5PoVfMexHjw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.62.10",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.62.10.tgz",
+      "integrity": "sha512-1e1WpHM5oGf27nWM/NWLY62/X9pbMBWa6ErWYmeuK0OqB9/g9UzA59ogiWbxCmS2wtAFQRhOdHhfSofrkhPl2g==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.62.9"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
       }
     },
     "node_modules/@types/estree": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "format": "prettier --cache --write ."
   },
   "dependencies": {
+    "@tanstack/react-query": "^5.62.10",
     "autoprefixer": "^10.4.20",
     "axios": "^1.7.9",
     "classnames": "^2.5.1",

--- a/src/api/review.api.ts
+++ b/src/api/review.api.ts
@@ -1,0 +1,47 @@
+import {
+  DeleteReviewRequest,
+  GetReviewRequest,
+  PostWineReviewRequest,
+  UpdateReviewRequest,
+} from '@/types/review.request';
+import {
+  DeleteReviewResponse,
+  GetReviewResponse,
+  PostWineReviewResponse,
+} from '@/types/review.response';
+
+import instance from '@/api/api';
+
+export const getReview = async ({ ...params }: GetReviewRequest) => {
+  const response = await instance<GetReviewResponse>({
+    method: 'GET',
+    url: `/reviews/${params.id}`,
+  });
+  return response;
+};
+
+export const postWineReview = async (reviewData: PostWineReviewRequest) => {
+  const response = await instance<PostWineReviewResponse>({
+    method: 'POST',
+    url: '/reviews',
+    data: reviewData,
+  });
+  return response;
+};
+
+export const updateReview = async ({ ...params }: UpdateReviewRequest) => {
+  const response = await instance<PostWineReviewResponse>({
+    method: 'PATCH',
+    url: `/reviews/${params.reviewId}`,
+    data: params.data,
+  });
+  return response.data;
+};
+
+export const deleteReview = async ({ ...params }: DeleteReviewRequest) => {
+  const response = await instance<DeleteReviewResponse>({
+    method: 'DELETE',
+    url: `/reviews/${params.id}`,
+  });
+  return response;
+};

--- a/src/api/wine.api.ts
+++ b/src/api/wine.api.ts
@@ -1,5 +1,24 @@
 import instance from "./api";
 
+export interface PatchWineData {
+  name: string;
+  price: number;
+  region: string;
+  type: 'RED' | 'WHITE' | 'SPARKLING';
+  image: string;
+}
+
+export interface PatchReviewData {
+    rating:number;
+    lightBold:number;
+    smoothTannic:number;
+    drySweet:number;
+    softAcidic:number;
+    aroma:string[];
+    content:string;
+}
+
+
 // 이미지 업로드
 export const uploadWineImage = async (imgFile: File): Promise<string> => {
   const accessToken = `Bearer ${localStorage.getItem("accessToken")}`;
@@ -49,3 +68,59 @@ export async function deleteWine({ id }: { id: number }) {
 
   return response;
 }
+
+export async function deleteReview({ id }: { id: number }) {
+  const response = await instance<{
+    id?: number;
+    message?: string;
+  }>({
+    method: "DELETE", 
+    url: `/reviews/${id}`,
+  });
+ 
+  return response;
+ }
+
+
+
+ export const getWine = async (wineId: number) => {
+  try {
+    const response = await instance.get(`/wines/${wineId}`);
+    return response.data;
+  } catch {
+    console.log('와인등록 정보 불러오기 오류');
+  }
+};
+
+export const patchWine = async (
+  wineId: number,
+  data: PatchWineData,
+): Promise<void> => {
+  try {
+    await instance.patch(`/wines/${wineId}`, data);
+  } catch (err) {
+    console.error(err);
+    alert('와인 수정 중 오류가 발생했습니다.');
+  }
+};
+
+export const getReview = async (reviewId: number) => {
+  try {
+    const response = await instance.get(`/reviews/${reviewId}`);
+    return response.data;
+  } catch {
+    console.log('리뷰 정보 불러오기 오류');
+  }
+};
+
+export const patchReview = async (
+  reviewId: number,
+  data: PatchReviewData,
+): Promise<void> => {
+  try {
+    await instance.patch(`/reviews/${reviewId}`, data);
+  } catch (err) {
+    console.error(err);
+    alert('리뷰 수정 중 오류가 발생했습니다.');
+  }
+};

--- a/src/app/review-test/page.tsx
+++ b/src/app/review-test/page.tsx
@@ -14,9 +14,10 @@ function Test() {
   const handleReviewClick = () => {
     setIsReviewOpen(!isReviewOpen);
   };
+  
 
   const wineDetail = {
-    id: 1,
+    id: 1264,
     name: "테스트 와인"
   };
 

--- a/src/app/review-test/page.tsx
+++ b/src/app/review-test/page.tsx
@@ -1,9 +1,12 @@
 "use client";
 
-import AddReviewModal from "@/components/modal-review/AddReviewModal";
+import ReviewModal from "@/components/modal-review/modal-review-edit";
 import ReviewProvider from "@/provider/usereviewmodals";
 import Button from "@/components/common/Button";
 import { useState } from "react";
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+const queryClient = new QueryClient();
 
 function Test() {
   const [isReviewOpen, setIsReviewOpen] = useState(false);
@@ -12,20 +15,39 @@ function Test() {
     setIsReviewOpen(!isReviewOpen);
   };
 
+  const wineDetail = {
+    id: 1,
+    name: "테스트 와인"
+  };
+
+  const testReviewId = 1;
+
   return (
-    <ReviewProvider>
-      <main className="grid grid-cols-3 gap-8 bg-white p-8">
-        <Button
-          type="button"
-          size="large"
-          color="secondary"
-          onClick={handleReviewClick}
-        >
-          리뷰모달열기
-        </Button>
-        <AddReviewModal isOpen={isReviewOpen} onClick={handleReviewClick} />
-      </main>
-    </ReviewProvider>
+    <QueryClientProvider client={queryClient}>
+      <ReviewProvider>
+        <main className="grid grid-cols-3 gap-8 bg-white p-8">
+          <Button
+            type="button"
+            size="large"
+            color="secondary"
+            onClick={handleReviewClick}
+          >
+            리뷰모달열기
+          </Button>
+          <ReviewModal 
+            isOpen={isReviewOpen} 
+            onClick={handleReviewClick}
+            mode="edit"
+            wineDetail={wineDetail}
+            reviewId={testReviewId}
+            onUpdate={(data) => {
+              console.log('Updated review:', data);
+              handleReviewClick();
+            }}
+          />
+        </main>
+      </ReviewProvider>
+    </QueryClientProvider>
   );
 }
 

--- a/src/app/test/addwine/page.tsx
+++ b/src/app/test/addwine/page.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useState } from "react";
-import Modal from "@/components/common/modal-container";
 import AddWine from "@/components/common/modal-add-wine";
 import DropDownMenu from "@/components/common/dropdown-menu";
 
@@ -33,15 +32,15 @@ export default function TestPage() {
           와인 등록하기
         </button>
 
-        <Modal isOpen={isModalOpen} onClose={handleCloseModal}>
-          <AddWine onClose={handleCloseModal} />
-        </Modal>
+        <AddWine isOpen={isModalOpen} onClick={handleCloseModal} />
       </div>
 
       <div className="flex items-center" style={{ gap: "1.6rem" }}>
         <h1 className="text-[1.6rem]">드롭다운 메뉴 테스트</h1>
-        <DropDownMenu onEdit={handleEdit} onDelete={handleDelete} />
-      </div>
+        <DropDownMenu onEdit={handleEdit} onDelete={handleDelete}>
+  <button className="w-8 h-8">⋮</button> {/* 또는 원하는 트리거 버튼 */}
+</DropDownMenu>
     </div>
+  </div>
   );
 }

--- a/src/components/common/modal-add-wine.tsx
+++ b/src/components/common/modal-add-wine.tsx
@@ -1,4 +1,4 @@
-"use client";
+/*"use client";
 
 import { useState } from "react";
 import { NewWineData, WineType } from "@/types/tasting";
@@ -385,3 +385,4 @@ export default function AddWine({ onClose }: Props) {
     </div>
   );
 }
+  */

--- a/src/components/modal-review/modal-review-edit.tsx
+++ b/src/components/modal-review/modal-review-edit.tsx
@@ -1,0 +1,198 @@
+"use client";
+
+import { useReviewModalStore } from "@/provider/usereviewmodals";
+import { FormEvent,useEffect } from "react";
+import Button from "@/components/common/Button";
+import Modalv from "@/components/common/modal-container-review";
+import ReviewInput from "@/components/modal-review/ReviewInput";
+import TagSelector from "@/components/modal-review/TagSelector";
+import TasteSlider from "@/components/modal-review/TasteSlider";
+import { convertToAroma } from "@/utils/translate-aroma";
+import {
+  useAddReview,
+  useReview,
+  useUpdateReview,
+} from '@/types/reviews.queries';
+
+
+type WineDetailProps = {
+  id: number;
+  name: string;
+};
+
+type ReviewResponse = {
+  id: number;
+  rating: number;
+  content: string;
+  aroma: string[];
+  lightBold: number;
+  smoothTannic: number;
+  drySweet: number;
+  softAcidic: number;
+};
+
+export type ReviewModalProps = {
+  isOpen: boolean;
+  onClick: () => void;
+  mode: 'add' | 'edit';
+  wineDetail: WineDetailProps;
+  reviewId?: number;
+  onUpdate?: (data: ReviewResponse) => void;  // any를 구체적인 타입으로 변경
+};
+
+export default function ReviewModal({
+  isOpen,
+  onClick,
+  mode,
+  wineDetail,
+  reviewId,
+  onUpdate,
+}: ReviewModalProps) {
+  const {
+    data: serverReviewData,
+    isLoading: isReviewLoading,
+    refetch: refetchReview,
+  } = useReview({
+    id: reviewId || 0,
+  });
+  const { mutate: updateReview } = useUpdateReview();
+  const { mutate: addReview } = useAddReview();
+
+  const {
+    rating,
+    content,
+    tasteValues,
+    selectedTags: aroma, // aroma를 selectedTags로 사용
+    resetReview,
+    setId,
+    setContent,
+    setRating,
+    setTasteValues,
+    setSelectedTags,
+  } = useReviewModalStore();
+
+  useEffect(() => {
+    if (isOpen && mode === 'edit' && reviewId && refetchReview) {
+      refetchReview(); // 모달이 열릴 때 데이터를 다시 불러옴
+    } else {
+      resetReview();
+    }
+
+    if (mode === 'edit' && serverReviewData && !isReviewLoading) {
+      setId(serverReviewData.id);
+      setContent(serverReviewData.content);
+      setRating(serverReviewData.rating);
+      setTasteValues([
+        serverReviewData.lightBold,
+        serverReviewData.smoothTannic,
+        serverReviewData.drySweet,
+        serverReviewData.softAcidic,
+      ]);
+      setSelectedTags(serverReviewData.aroma);
+    }
+  }, [
+    mode,
+    setId,
+    setContent,
+    setRating,
+    setTasteValues,
+    setSelectedTags,
+    resetReview,
+    serverReviewData,
+    isOpen,
+    isReviewLoading,
+    refetchReview,
+    reviewId,
+  ]);
+
+  const handleSubmit = async (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+  
+    if (mode === 'edit' && serverReviewData) {
+      await updateReview({
+        reviewId: serverReviewData.id,
+        data: {
+          rating,
+          content,
+          aroma: convertToAroma(aroma),
+          lightBold: tasteValues[0],
+          smoothTannic: tasteValues[1],
+          drySweet: tasteValues[2],
+          softAcidic: tasteValues[3],
+        },
+      });
+  
+      // serverReviewData를 직접 onUpdate에 전달
+      onUpdate!(serverReviewData);
+    } else if (mode === 'add') {
+      await addReview({
+        wineId: wineDetail.id,
+        rating,
+        content,
+        aroma: convertToAroma(aroma),
+        lightBold: tasteValues[0],
+        smoothTannic: tasteValues[1],
+        drySweet: tasteValues[2],
+        softAcidic: tasteValues[3],
+      });
+    }
+  
+    resetReview();
+    onClick();
+  };
+
+  const isButtonDisabled = !rating || !content || aroma.length === 0;
+
+  return (
+    <Modalv isOpen={isOpen} onClose={onClick}>
+    <div className="w-full h-auto rounded-[1.8rem] bg-white pt-[3.2rem] px-[2.4rem] pb-[2.4rem] tablet:pt-[2.4rem] tablet:px-[2.4rem] tablet:pb-[2.4rem]">
+      <section className="flex justify-between items-center">
+        <h1 className="text-gray-800 m-0 font-bold text-[2rem] tablet:text-[2.4rem]">
+                        {mode === 'add' ? '리뷰 등록' : '리뷰 수정'}
+
+          </h1>
+          <button
+            type="button"
+            onClick={onClick}
+            className="text-gray-500 text-[1.6rem] tablet:text-[2rem]"
+            >
+            X
+          </button>
+        </section>
+      <form className="w-full" onSubmit={handleSubmit}>
+            <ReviewInput />
+            <div className="relative inline-block mb-[2rem]">
+            <p className="text-gray-800 font-bold text-[1.6rem] tablet:text-[1.8rem] cursor-pointer 
+border-b-[0.4rem] border-dotted border-transparent 
+hover:border-primary hover:mb-[1rem] hover:pb-[0.5rem]
+transition-all duration-300">
+와인의 맛은 어땠나요?
+</p>
+</div>
+          <TasteSlider />
+          <div className="relative inline-block mt-[4rem] mb-[2rem]">
+        <p className="text-gray-800 font-bold text-[1.6rem] tablet:text-[1.8rem] cursor-pointer 
+border-b-[0.4rem] border-dotted border-transparent 
+hover:border-primary hover:mb-[1rem] hover:pb-[0.5rem]
+transition-all duration-300">       기억에 남는 향이 있나요?
+          </p>
+        </div>
+
+
+          <TagSelector />
+          <div className="flex mt-[4rem]">
+          <Button
+            type="submit"
+            size="large"
+            color="primary"
+            addClassName="w-full text-[1.6rem] tablet:text-[1.5rem] font-bold rounded-[1rem] h-[5.4rem]"
+              disabled={isButtonDisabled}
+            >
+              {mode === 'add' ? '리뷰 남기기' : '리뷰 수정하기'}
+            </Button>
+          </div>
+        </form>
+      </div>
+    </Modalv>
+  );
+}

--- a/src/components/modal-review/modal-review-edit.tsx
+++ b/src/components/modal-review/modal-review-edit.tsx
@@ -40,6 +40,8 @@ export type ReviewModalProps = {
   onUpdate?: (data: ReviewResponse) => void;  // any를 구체적인 타입으로 변경
 };
 
+
+
 export default function ReviewModal({
   isOpen,
   onClick,
@@ -58,6 +60,7 @@ export default function ReviewModal({
   const { mutate: updateReview } = useUpdateReview();
   const { mutate: addReview } = useAddReview();
 
+  
   const {
     rating,
     content,
@@ -71,39 +74,39 @@ export default function ReviewModal({
     setSelectedTags,
   } = useReviewModalStore();
 
-  useEffect(() => {
-    if (isOpen && mode === 'edit' && reviewId && refetchReview) {
-      refetchReview(); // 모달이 열릴 때 데이터를 다시 불러옴
-    } else {
-      resetReview();
-    }
+// 데이터 fetch
+useEffect(() => {
+  if (isOpen && mode === 'edit' && reviewId && refetchReview) {
+    refetchReview();
+  } else {
+    resetReview();
+  }
+}, [isOpen, mode, reviewId, refetchReview, resetReview]);
 
-    if (mode === 'edit' && serverReviewData && !isReviewLoading) {
-      setId(serverReviewData.id);
-      setContent(serverReviewData.content);
-      setRating(serverReviewData.rating);
-      setTasteValues([
-        serverReviewData.lightBold,
-        serverReviewData.smoothTannic,
-        serverReviewData.drySweet,
-        serverReviewData.softAcidic,
-      ]);
-      setSelectedTags(serverReviewData.aroma);
-    }
-  }, [
-    mode,
-    setId,
-    setContent,
-    setRating,
-    setTasteValues,
-    setSelectedTags,
-    resetReview,
-    serverReviewData,
-    isOpen,
-    isReviewLoading,
-    refetchReview,
-    reviewId,
-  ]);
+// 데이터 설정
+useEffect(() => {
+  if (mode === 'edit' && serverReviewData && !isReviewLoading) {
+    setId(serverReviewData.id);
+    setContent(serverReviewData.content);
+    setRating(serverReviewData.rating);
+    setTasteValues([
+      serverReviewData.lightBold,
+      serverReviewData.smoothTannic,
+      serverReviewData.drySweet,
+      serverReviewData.softAcidic,
+    ]);
+    setSelectedTags(serverReviewData.aroma);
+  }
+}, [
+  mode, 
+  serverReviewData, 
+  isReviewLoading,
+  setId,
+  setContent,
+  setRating,
+  setTasteValues,
+  setSelectedTags
+]);
 
   const handleSubmit = async (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();

--- a/src/provider/usereviewmodals.tsx
+++ b/src/provider/usereviewmodals.tsx
@@ -8,11 +8,13 @@ type ReviewState = {
   wineId: number;
   wineName: string;
   rating: number;
+  id: number | undefined;  // id 타입 정의
   setContent: (content: string) => void;
   setSelectedTags: (tags: string[]) => void;
   setTasteValues: (values: number[]) => void;
   setWineId: (id: number) => void;
   setRating: (rating: number) => void;
+  setId: (id: number) => void;  // setId 추가
   resetReview: () => void;
 };
 
@@ -30,11 +32,14 @@ const ReviewProvider = ({ children }: { children: React.ReactNode }) => {
   const [wineId, setWineId] = useState(TestWineDetail.id);
   const [wineName] = useState(TestWineDetail.name);
   const [rating, setRating] = useState(0);
+  const [id, setId] = useState<number | undefined>(undefined);  // id state 추가
 
   const resetReview = () => {
     setContent("");
     setSelectedTags([]);
     setTasteValues([50, 50, 50, 50]);
+    setRating(0);
+    setId(undefined);  // id도 리셋
   };
 
   const value = {
@@ -44,11 +49,13 @@ const ReviewProvider = ({ children }: { children: React.ReactNode }) => {
     wineId,
     wineName,
     rating,
+    id,  // id 추가
     setContent,
     setSelectedTags,
     setTasteValues,
     setWineId,
     setRating,
+    setId,  // setId 추가
     resetReview,
   };
 

--- a/src/provider/usereviewmodals.tsx
+++ b/src/provider/usereviewmodals.tsx
@@ -1,75 +1,75 @@
 "use client";
-import { createContext, useContext, useState } from "react";
+import { createContext, useContext, useState, useCallback } from "react";
 
 type ReviewState = {
-  content: string;
-  selectedTags: string[];
-  tasteValues: number[];
-  wineId: number;
-  wineName: string;
-  rating: number;
-  id: number | undefined;  // id 타입 정의
-  setContent: (content: string) => void;
-  setSelectedTags: (tags: string[]) => void;
-  setTasteValues: (values: number[]) => void;
-  setWineId: (id: number) => void;
-  setRating: (rating: number) => void;
-  setId: (id: number) => void;  // setId 추가
-  resetReview: () => void;
+ content: string;
+ selectedTags: string[];
+ tasteValues: number[];
+ wineId: number;
+ wineName: string;
+ rating: number;  
+ id: number | undefined;
+ setContent: (content: string) => void;
+ setSelectedTags: (tags: string[]) => void;
+ setTasteValues: (values: number[]) => void;
+ setWineId: (id: number) => void;
+ setRating: (rating: number) => void;
+ setId: (id: number) => void;
+ resetReview: () => void;
 };
 
 const TestWineDetail = {
-  id: 3,
-  name: "Sentinel Carbernet Sauvignon 2016",
+ id: 504,
+ name: "Sentinel Carbernet Sauvignon 2016",
 };
 
 export const ReviewContext = createContext<ReviewState | null>(null);
 
 const ReviewProvider = ({ children }: { children: React.ReactNode }) => {
-  const [content, setContent] = useState("");
-  const [selectedTags, setSelectedTags] = useState<string[]>([]);
-  const [tasteValues, setTasteValues] = useState([50, 50, 50, 50]);
-  const [wineId, setWineId] = useState(TestWineDetail.id);
-  const [wineName] = useState(TestWineDetail.name);
-  const [rating, setRating] = useState(0);
-  const [id, setId] = useState<number | undefined>(undefined);  // id state 추가
+ const [content, setContent] = useState("");
+ const [selectedTags, setSelectedTags] = useState<string[]>([]);
+ const [tasteValues, setTasteValues] = useState([50, 50, 50, 50]);
+ const [wineId, setWineId] = useState(TestWineDetail.id);
+ const [wineName] = useState(TestWineDetail.name);
+ const [rating, setRating] = useState(0);
+ const [id, setId] = useState<number | undefined>(undefined);
 
-  const resetReview = () => {
-    setContent("");
-    setSelectedTags([]);
-    setTasteValues([50, 50, 50, 50]);
-    setRating(0);
-    setId(undefined);  // id도 리셋
-  };
+ const resetReview = useCallback(() => {
+   setContent("");
+   setSelectedTags([]);
+   setTasteValues([50, 50, 50, 50]);
+   setRating(0);
+   setId(undefined);
+ }, []); // useCallback으로 감싸기
 
-  const value = {
-    content,
-    selectedTags,
-    tasteValues,
-    wineId,
-    wineName,
-    rating,
-    id,  // id 추가
-    setContent,
-    setSelectedTags,
-    setTasteValues,
-    setWineId,
-    setRating,
-    setId,  // setId 추가
-    resetReview,
-  };
+ const value = {
+   content,
+   selectedTags,
+   tasteValues,
+   wineId,
+   wineName,
+   rating,
+   id,
+   setContent,
+   setSelectedTags,
+   setTasteValues,
+   setWineId,
+   setRating,
+   setId,
+   resetReview,
+ };
 
-  return (
-    <ReviewContext.Provider value={value}>{children}</ReviewContext.Provider>
-  );
+ return (
+   <ReviewContext.Provider value={value}>{children}</ReviewContext.Provider>
+ );
 };
 
 export default ReviewProvider;
 
 export function useReviewModalStore() {
-  const context = useContext(ReviewContext);
-  if (!context) {
-    throw new Error("useReviewModalStore must be used within a ReviewProvider");
-  }
-  return context;
+ const context = useContext(ReviewContext);
+ if (!context) {
+   throw new Error("useReviewModalStore must be used within a ReviewProvider");
+ }
+ return context;
 }

--- a/src/types/review.request.ts
+++ b/src/types/review.request.ts
@@ -1,0 +1,33 @@
+import { ReviewDetailType } from '@/types/review.types';
+
+export type GetReviewRequest = Pick<ReviewDetailType, 'id'>;
+
+export type UpdateReviewRequest = {
+  reviewId: number;
+  data: Pick<
+    ReviewDetailType,
+    | 'rating'
+    | 'lightBold'
+    | 'smoothTannic'
+    | 'drySweet'
+    | 'softAcidic'
+    | 'aroma'
+    | 'content'
+  >;
+};
+
+export type PostWineReviewRequest = Pick<
+  ReviewDetailType,
+  | 'rating'
+  | 'lightBold'
+  | 'smoothTannic'
+  | 'drySweet'
+  | 'softAcidic'
+  | 'aroma'
+  | 'content'
+  | 'wineId'
+>;
+
+export type DeleteReviewRequest = {
+  id: number;
+};

--- a/src/types/review.response.ts
+++ b/src/types/review.response.ts
@@ -1,0 +1,77 @@
+ 
+import { Aroma } from "@/types/aroma";
+
+// 리뷰 작성자 정보
+export type ReviewUser = {
+  id: number;
+  nickname: string;
+  image: string | null; // nullable true
+};
+
+// 리뷰 리스트 항목
+export type ReviewListType = {
+  id: number;
+  rating: number;
+  lightBold: number;
+  smoothTannic: number;
+  drySweet: number;
+  softAcidic: number;
+  aroma: Aroma[]; // Aroma Enum 사용
+  content: string;
+  createdAt: string; // 날짜 시간 형식
+  updatedAt: string; // 날짜 시간 형식
+  user: ReviewUser;
+};
+
+// 리뷰 상세 정보 타입
+export type ReviewDetailType = {
+  id: number;
+  rating: number;
+  lightBold: number;
+  smoothTannic: number;
+  drySweet: number;
+  softAcidic: number;
+  aroma: Aroma[]; // Aroma Enum 배열
+  content: string;
+  createdAt: string; // ISO 8601 날짜 시간 형식
+  updatedAt: string; // ISO 8601 날짜 시간 형식
+  user: ReviewUser;
+  wineId: number;
+  teamId: string;
+};
+
+// 평균 평점 정보
+export type AvgRatings = {
+  [key: string]: number; // 동적 속성 이름에 대한 숫자 값
+};
+
+// 최근 리뷰 타입
+export type RecentReview = {
+  id: number;
+  rating: number;
+  lightBold?: number;
+  smoothTannic?: number;
+  drySweet?: number;
+  softAcidic?: number;
+  aroma: Aroma[]; // Aroma Enum 배열
+  content: string;
+  createdAt: string; // ISO 8601 날짜 시간 형식
+  updatedAt: string; // ISO 8601 날짜 시간 형식
+  user: ReviewUser;
+};
+
+export type WineTastes = {
+  lightBold: number;
+  smoothTannic: number;
+  drySweet: number;
+  softAcidic: number;
+};
+
+export type DeleteReviewResponse = {
+  id?: number;
+  message?: string;
+};
+
+export type GetReviewResponse = ReviewDetailType;
+
+export type PostWineReviewResponse = ReviewDetailType;

--- a/src/types/review.response.ts
+++ b/src/types/review.response.ts
@@ -1,5 +1,5 @@
  
-import { Aroma } from "@/types/aroma";
+import { Aroma } from "@/types/tasting";
 
 // 리뷰 작성자 정보
 export type ReviewUser = {

--- a/src/types/review.types.ts
+++ b/src/types/review.types.ts
@@ -1,0 +1,69 @@
+ import { Aroma } from "@/types/tasting";
+
+// 리뷰 작성자 정보
+export type ReviewUser = {
+  id: number;
+  nickname: string;
+  image: string | null; // nullable true
+};
+
+// 리뷰 리스트 항목
+export type ReviewListType = {
+  id: number;
+  rating: number;
+  lightBold: number;
+  smoothTannic: number;
+  drySweet: number;
+  softAcidic: number;
+  aroma: Aroma[]; // Aroma Enum 사용
+  content: string;
+  createdAt: string; // 날짜 시간 형식
+  updatedAt: string; // 날짜 시간 형식
+  user: ReviewUser;
+};
+
+// 리뷰 상세 정보 타입
+export type ReviewDetailType = {
+  id: number;
+  rating: number;
+  lightBold: number;
+  smoothTannic: number;
+  drySweet: number;
+  softAcidic: number;
+  aroma: Aroma[]; // Aroma Enum 배열
+  content: string;
+  createdAt: string; // ISO 8601 날짜 시간 형식
+  updatedAt: string; // ISO 8601 날짜 시간 형식
+  user: ReviewUser;
+  wineId: number;
+  teamId: string;
+};
+
+// 평균 평점 정보
+export type AvgRatings = {
+  [key: string]: number; // 동적 속성 이름에 대한 숫자 값
+};
+
+// 최근 리뷰 타입
+export type RecentReview = {
+  id: number;
+  rating: number;
+  lightBold?: number;
+  smoothTannic?: number;
+  drySweet?: number;
+  softAcidic?: number;
+  aroma: Aroma[]; // Aroma Enum 배열
+  content: string;
+  createdAt: string; // ISO 8601 날짜 시간 형식
+  updatedAt: string; // ISO 8601 날짜 시간 형식
+  user: ReviewUser;
+};
+
+export type WineTastes = {
+  lightBold: number;
+  smoothTannic: number;
+  drySweet: number;
+  softAcidic: number;
+};
+
+

--- a/src/types/reviews.queries.ts
+++ b/src/types/reviews.queries.ts
@@ -1,0 +1,61 @@
+import {
+  deleteReview,
+  getReview,
+  postWineReview,
+  updateReview,
+} from '@/api/review.api';
+import { GetReviewRequest } from '@/types/review.request';
+import { GetReviewResponse } from '@/types/review.response';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+
+export function useReview({ ...params }: GetReviewRequest) {
+  const { data, error, isLoading, refetch } = useQuery<GetReviewResponse>({
+    queryKey: ['reviewDetail', params.id],
+    queryFn: async () => {
+      const response = await getReview(params);
+      return response.data;
+    },
+    enabled: params.id !== 0,
+  });
+  return { data, error, isLoading, refetch };
+}
+
+export function useAddReview() {
+  const queryClient = useQueryClient();
+  const { mutate, data, error, isError, isPending } = useMutation({
+    mutationKey: ['addReview'],
+    mutationFn: postWineReview,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['reviewDetail'] });
+      queryClient.invalidateQueries({ queryKey: ['wineDetail'] });
+    },
+  });
+  return { mutate, data, error, isError, isPending };
+}
+
+export function useUpdateReview() {
+  const queryClient = useQueryClient();
+  const { mutate, data, error, isError, isPending } = useMutation({
+    mutationKey: ['updateReview'],
+    mutationFn: updateReview,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['reviewDetail'] });
+      queryClient.invalidateQueries({ queryKey: ['wineDetail'] });
+    },
+  });
+  return { mutate, data, error, isError, isPending };
+}
+
+export function useRemoveReview(onSuccess?: () => void) {
+  const queryClient = useQueryClient();
+  const { mutate: removeReview, isPending: isRemoveReviewPending } =
+    useMutation({
+      mutationFn: deleteReview,
+      onSuccess: () => {
+        queryClient.invalidateQueries({ queryKey: ['wineDetail'] });
+        onSuccess?.();
+      },
+    });
+
+  return { removeReview, isRemoveReviewPending };
+}

--- a/src/types/tasting.ts
+++ b/src/types/tasting.ts
@@ -1,14 +1,84 @@
+import { AvgRatings, RecentReview, ReviewListType } from './review.types';
+
+// WineType Enum 정의
 export enum WineType {
   None = "",
-  Red = "RED",
-  White = "WHITE",
-  Sparkling = "SPARKLING",
+  RED = 'RED',
+  WHITE = 'WHITE',
+  SPARKLING = 'SPARKLING',
 }
 
-export interface NewWineData {
+// Aroma에 대한 Enum 정의
+export enum Aroma {
+  CHERRY = 'CHERRY',
+  BERRY = 'BERRY',
+  OAK = 'OAK',
+  VANILLA = 'VANILLA',
+  PEPPER = 'PEPPER',
+  BAKING = 'BAKING',
+  GRASS = 'GRASS',
+  APPLE = 'APPLE',
+  PEACH = 'PEACH',
+  CITRUS = 'CITRUS',
+  TROPICAL = 'TROPICAL',
+  MINERAL = 'MINERAL',
+  FLOWER = 'FLOWER',
+  TOBACCO = 'TOBACCO',
+  EARTH = 'EARTH',
+  CHOCOLATE = 'CHOCOLATE',
+  SPICE = 'SPICE',
+  CARAMEL = 'CARAMEL',
+  LEATHER = 'LEATHER',
+}
+
+export enum AromaKorean {
+  CHERRY = '체리',
+  BERRY = '베리',
+  OAK = '오크',
+  VANILLA = '바닐라',
+  PEPPER = '후추',
+  BAKING = '베이킹',
+  GRASS = '풀',
+  APPLE = '사과',
+  PEACH = '복숭아',
+  CITRUS = '시트러스',
+  TROPICAL = '열대과일',
+  MINERAL = '미네랄',
+  FLOWER = '꽃',
+  TOBACCO = '담배',
+  EARTH = '흙',
+  CHOCOLATE = '초콜릿',
+  SPICE = '향신료',
+  CARAMEL = '카라멜',
+  LEATHER = '가죽',
+}
+
+// 와인 상세 정보 타입
+export type WineDetailType = {
+  id: number;
   name: string;
   region: string;
-  image: string | File; // 수정
+  image: string;
   price: number;
-  type: WineType;
-}
+  type: string;
+  avgRating: number;
+  reviewCount: number;
+  recentReview: RecentReview | null; // nullable true
+  userId: number;
+  reviews: ReviewListType[];
+  avgRatings: AvgRatings;
+};
+
+// 와인 리스트 정보 타입
+export type WineListType = {
+  id: number;
+  name: string;
+  region: string;
+  image: string;
+  price: number;
+  type: string; // "RED", "WHITE", "SPARKLING" 중 하나
+  avgRating: number;
+  reviewCount: number;
+  recentReview: RecentReview | null; // nullable true
+  userId?: number;
+};

--- a/src/utils/translate-aroma.ts
+++ b/src/utils/translate-aroma.ts
@@ -1,0 +1,12 @@
+import { Aroma } from '@/types/tasting';
+
+export function convertToAroma(aromas: string[]): Aroma[] {
+  return aromas
+    .map((aroma) => {
+      if (Object.values(Aroma).includes(aroma as Aroma)) {
+        return aroma as Aroma;
+      }
+      return null;
+    })
+    .filter((aroma): aroma is Aroma => aroma !== null);
+}


### PR DESCRIPTION
## 🪐 작업 내용
modal-review-edit.tsx

### 📝 간단하게 설명해주세요

> 혹시 몰라서 리뷰 모달을 따로 만들었습니다.
api 연동 정상으로 되면
modal-review-edit 하나의 컴포넌트로 리뷰 등록, 수정
mode prop으로 등록, 수정 바꿔서 쓰시면 되고
등록(add) 모드: postWineReview 함수를 사용하여 새로운 리뷰를 생성
수정(edit) 모드: getReview로 기존 리뷰를 불러오고, updateReview 함수로 수정된 내용을 저장<br><br>


### ✨ To-do
- [x]  리뷰 등록: post함수를 사용하여 새로운 리뷰를 생성
- [x]  리뷰 수정: get으로 불러오고 patch로 수정<br><br>

### 📸 참고 사진<br><br>

_등록할 때_<br>
![Image](https://github.com/user-attachments/assets/1964a7a2-8235-4821-9cd8-163351f9258b)
![Image](https://github.com/user-attachments/assets/501088ad-d907-4f81-8e34-3da7da65a26f)<br><br><br>

_수정할 때_<br>
![Image](https://github.com/user-attachments/assets/e74ec81e-798c-46f1-b6f6-ab1040828e9f)
![Image](https://github.com/user-attachments/assets/b17d958d-6bd2-465a-bb8a-0b5461dd76b9)<br><br><br>



